### PR TITLE
Update Parsoid key

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 parsoid_key_local_file: /root/parsoid.gpg
-parsoid_key_fingerprint: 90E9F83F22250DD7
+parsoid_key_fingerprint: AF380A3036A03444
 parsoid_worker_heartbeat_timeout: 300000
 parsoid_logging_level: "info"
 parsoid_conf: {}


### PR DESCRIPTION
Parsoid updated its GPG key on 2016-07-27 and on 2019-06-13
respectively. If you installed Parsoid prior to this date, you will
need to follow the instructions below to add the new Parsoid GPG key
before you will get updated packages.

https://www.mediawiki.org/wiki/Parsoid/Setup